### PR TITLE
fix installation@readme for ghq get

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ For more information, see `man git-diff-files`.
 or
 
 	$ ghq get b4b4r07/gch
+	$ go install github.com/b4b4r07/gch
 
 ## License
 


### PR DESCRIPTION
this command don't generated gch binary file

```
$ ghq get b4b4r07/gch
```
